### PR TITLE
Resolved Code Checker Errors.

### DIFF
--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -145,7 +145,7 @@ class provider implements metadata_provider, request_provider,
         $metadatafields = [
             'userid' => 'privacy:metadata:tool_googleadmin_users:userid',
             'email' => 'privacy:metadata:tool_googleadmin_users:email',
-            'password' => 'privacy:metadata:tool_googleadmin_users:password'
+            'password' => 'privacy:metadata:tool_googleadmin_users:password',
         ];
 
         $collection->add_database_table('tool_googleadmin_users', $metadatafields, 'privacy:metadata:tool_googleadmin_users');
@@ -153,7 +153,7 @@ class provider implements metadata_provider, request_provider,
         $externalfields = [
             'userid' => 'privacy:metadata:google_apps:userid',
             'email' => 'privacy:metadata:google_apps:email',
-            'password' => 'privacy:metadata:google_apps:password'
+            'password' => 'privacy:metadata:google_apps:password',
         ];
 
         $collection->add_external_location_link('google_apps', $externalfields, 'privacy:metadata:google_apps');

--- a/db/access.php
+++ b/db/access.php
@@ -33,19 +33,19 @@ $capabilities = array(
         'contextlevel'         => CONTEXT_BLOCK,
         'archetypes'           => array(
             'editingteacher' => CAP_ALLOW,
-            'manager'        => CAP_ALLOW
+            'manager'        => CAP_ALLOW,
         ),
 
-        'clonepermissionsfrom' => 'moodle/site:manageblocks'
+        'clonepermissionsfrom' => 'moodle/site:manageblocks',
     ),
 
     'block/gapps:myaddinstance' => array(
         'captype'              => 'write',
         'contextlevel'         => CONTEXT_SYSTEM,
         'archetypes'           => array(
-            'user' => CAP_ALLOW
+            'user' => CAP_ALLOW,
         ),
 
-        'clonepermissionsfrom' => 'moodle/my:manageblocks'
+        'clonepermissionsfrom' => 'moodle/my:manageblocks',
     ),
 );

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -29,7 +29,7 @@ use block_gapps\privacy\provider;
 use core_privacy\local\request\approved_contextlist;
 use core_privacy\local\request\writer;
 use core_privacy\tests\provider_testcase;
-use \core_privacy\local\request\approved_userlist;
+use core_privacy\local\request\approved_userlist;
 
 
 class privacy_provider_test extends provider_testcase {


### PR DESCRIPTION
1. **Fixed array syntax issues.**
Added a comma to the last item of the array.

2. **Removed backslash to fix an error.**